### PR TITLE
Update gitignore to add `pd` and `imgui.ini`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 
 # files generated when running tolvera applications
-pd/
+pd
 imgui.ini
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# files generated when running tolvera applications
+pd/
+imgui.ini
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Changes made:
- Add `pd` and `imgui.ini` to .gitignore as these are autogenerated when running tolvera code.