### PR TITLE
fix: add docstring to cv.py

### DIFF
--- a/src/tolvera/cv.py
+++ b/src/tolvera/cv.py
@@ -6,21 +6,24 @@ and converting between OpenCV's image representation and Tolvera's pixel represe
 
 Example:
     Basic usage with webcam input.
-    ```py
-    import taichi as ti
-    from tolvera import Tolvera, run
+    
+    $ python tolvera/cv/show_camera.py --cv True --camera True --device 0
 
-    def main(**kwargs):
-        tv = Tolvera(**kwargs)
-        cv = tv.CV(camera=True, device=0)  # Use default webcam
+    ```py
+        from tolvera import Tolvera, run
+
+        def main(**kwargs):
+            tv = Tolvera(**kwargs)
+
+            @tv.render 
+            def _():
+                tv.cv()
+                tv.px.set(tv.cv.px)
+                return tv.px
+
+        if __name__ == '__main__':
+            run(main)
         
-        @tv.render
-        def _():
-            cv()  # Process a frame from the camera
-            return cv.px  # Return the pixels for rendering
-            
-    if __name__ == '__main__':
-        run(main)
     ```
 """
 
@@ -289,7 +292,7 @@ class CV:
             float: Percentage of different pixels.
         """
         self.diff = cv.absdiff(a, b)
-        diff = self.diff
+        diff = self.diff #.astype(np.uint8)
         self.diff_p = (np.count_nonzero(diff) * 100) / diff.size
         print('diff', self.diff_p)
         return self.diff_p

--- a/src/tolvera/cv.py
+++ b/src/tolvera/cv.py
@@ -1,3 +1,29 @@
+"""CV module.
+
+This module provides computer vision capabilities for the Tolvera framework.
+It allows for capturing video from a camera or video file, processing images,
+and converting between OpenCV's image representation and Tolvera's pixel representation.
+
+Example:
+    Basic usage with webcam input.
+    ```py
+    import taichi as ti
+    from tolvera import Tolvera, run
+
+    def main(**kwargs):
+        tv = Tolvera(**kwargs)
+        cv = tv.CV(camera=True, device=0)  # Use default webcam
+        
+        @tv.render
+        def _():
+            cv()  # Process a frame from the camera
+            return cv.px  # Return the pixels for rendering
+            
+    if __name__ == '__main__':
+        run(main)
+    ```
+"""
+
 import cv2 as cv
 import numpy as np
 import taichi as ti
@@ -7,7 +33,27 @@ from .pixels import Pixels
 
 @ti.data_oriented
 class CV:
+    """Computer Vision class for image processing and camera input.
+    
+    This class provides methods for capturing video from a camera or video file,
+    processing images using OpenCV, and converting between OpenCV's image
+    representation and Tolvera's pixel representation.
+    """
+    
     def __init__(self, context, **kwargs) -> None:
+        """Initialize the CV class.
+        
+        Args:
+            context: The Tolvera context.
+            **kwargs: Keyword arguments.
+                ggui_fps_limit (int): Frame rate limit for GGUI. Defaults to 120.
+                substeps (int): Number of substeps per frame. Defaults to 2.
+                colormode (str): Color mode. Defaults to "rgba".
+                device (int): Camera device index. Defaults to 0.
+                camera (bool): Whether to use a camera. Defaults to False.
+                video (bool): Whether to use a video file. Defaults to False.
+                videofile (str): Path to video file. Defaults to None.
+        """
         self.ctx = context
         self.x, self.y = self.ctx.x, self.ctx.y
         self.px = Pixels(self.ctx, **kwargs)
@@ -29,6 +75,11 @@ class CV:
             self.capture_init(self._videofile)
 
     def capture_init(self, filename):
+        """Initialize a video capture from a camera device or video file.
+        
+        Args:
+            filename: Camera device index or path to video file.
+        """
         print(f"[{self.ctx.name}] Initialising video capture with '{filename}'...")
         self.camera_capture = cv.VideoCapture(filename)
         self.camera_x = self.camera_capture.get(cv.CAP_PROP_FRAME_WIDTH)
@@ -43,6 +94,11 @@ class CV:
             exit()
 
     def capture_read(self):
+        """Read a frame from the camera or video file.
+        
+        Returns:
+            numpy.ndarray: Frame as a float32 array.
+        """
         ret, self.cc_frame = self.camera_capture.read()
         if ret:
             self.cc_frame_f32 = self.cc_frame.astype(np.float32)
@@ -55,6 +111,17 @@ class CV:
             exit()
 
     def threshold(self, img, thresh=127, max=255, threshold_type="binary"):
+        """Apply a threshold to an image.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            thresh (int): Threshold value. Defaults to 127.
+            max (int): Maximum value to use with the threshold. Defaults to 255.
+            threshold_type (str): Type of thresholding. Can be "binary" or "otsu". Defaults to "binary".
+            
+        Returns:
+            numpy.ndarray: Thresholded image.
+        """
         if threshold_type == "binary":
             ret, thresh_img = cv.threshold(img, thresh, max, cv.THRESH_BINARY)
         elif threshold_type == "otsu":
@@ -74,6 +141,14 @@ class CV:
         return thresh_img
 
     def find_contours(self, thresh):
+        """Find contours in a thresholded image.
+        
+        Args:
+            thresh (numpy.ndarray): Thresholded image.
+            
+        Returns:
+            list: Contours found in the image.
+        """
         img = cv.cvtColor(thresh, cv.COLOR_BGR2GRAY)
         contours, hierarchy = cv.findContours(
             img, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE
@@ -82,55 +157,150 @@ class CV:
         return contours
 
     def approx_poly_dp(self, contours, epsilon=0.1):
+        """Approximate polygons from contours.
+        
+        Args:
+            contours (list): Contours to approximate.
+            epsilon (float): Approximation accuracy. Defaults to 0.1.
+            
+        Returns:
+            list: Approximated polygons.
+        """
         polygons = [cv.approxPolyDP(c, epsilon, True) for c in contours]
         self.polygons = polygons
         return polygons
 
     def draw_contours(self, contours, color=(255, 255, 255), thickness=5):
+        """Draw contours on a black image.
+        
+        Args:
+            contours (list): Contours to draw.
+            color (tuple): Color to draw contours with. Defaults to (255, 255, 255).
+            thickness (int): Thickness of contour lines. Defaults to 5.
+            
+        Returns:
+            numpy.ndarray: Image with drawn contours.
+        """
         img = np.zeros((self.y, self.x), np.uint8)
         img = cv.drawContours(img, contours, -1, color, thickness)
         self.contours_img = img
         return img
 
     def gaussian_blur(self, img, ksize=(25, 25), sigmaX=0):
+        """Apply a Gaussian blur to an image.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            ksize (tuple): Kernel size. Defaults to (25, 25).
+            sigmaX (float): Sigma value for X. Defaults to 0.
+            
+        Returns:
+            numpy.ndarray: Blurred image.
+        """
         img = cv.GaussianBlur(img, ksize, sigmaX)
         return img
 
     def resize(self, img, dsize=(1920, 1080), interpolation=cv.INTER_LINEAR):
+        """Resize an image.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            dsize (tuple): Destination size. Defaults to (1920, 1080).
+            interpolation: Interpolation method. Defaults to cv.INTER_LINEAR.
+            
+        Returns:
+            numpy.ndarray: Resized image.
+        """
         img = cv.resize(img, dsize, interpolation)
         return img
 
     def pyr_down(self, img, factor=1):
+        """Reduce an image using pyramid downsampling.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            factor (int): Number of times to apply pyramid downsampling. Defaults to 1.
+            
+        Returns:
+            numpy.ndarray: Downsampled image.
+        """
         for i in range(factor):
             img = cv.pyrDown(img)
         return img
 
     def pyr_up(self, img, factor=1):
+        """Enlarge an image using pyramid upsampling.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            factor (int): Number of times to apply pyramid upsampling. Defaults to 1.
+            
+        Returns:
+            numpy.ndarray: Upsampled image.
+        """
         for i in range(factor):
             img = cv.pyrUp(img)
         return img
 
     def bgr_to_gray(self, img):
+        """Convert a BGR image to grayscale.
+        
+        Args:
+            img (numpy.ndarray): Input BGR image.
+            
+        Returns:
+            numpy.ndarray: Grayscale image.
+        """
         img = cv.cvtColor(img, cv.COLOR_BGR2GRAY)
         return img
 
     def gray_to_bgr(self, img):
+        """Convert a grayscale image to BGR.
+        
+        Args:
+            img (numpy.ndarray): Input grayscale image.
+            
+        Returns:
+            numpy.ndarray: BGR image.
+        """
         img = cv.cvtColor(img, cv.COLOR_GRAY2BGR)
         return img
 
     def invert(self, img):
+        """Invert an image.
+        
+        Args:
+            img (numpy.ndarray): Input image.
+            
+        Returns:
+            numpy.ndarray: Inverted image.
+        """
         img = cv.bitwise_not(img)
         return img
 
     def abs_diff(self, a, b):
+        """Calculate the absolute difference between two images.
+        
+        Args:
+            a (numpy.ndarray): First image.
+            b (numpy.ndarray): Second image.
+            
+        Returns:
+            float: Percentage of different pixels.
+        """
         self.diff = cv.absdiff(a, b)
-        diff = self.diff#.astype(np.uint8)
+        diff = self.diff
         self.diff_p = (np.count_nonzero(diff) * 100) / diff.size
         print('diff', self.diff_p)
         return self.diff_p
 
     @ti.kernel
     def cv_to_px(self, f: ti.types.ndarray(dtype=ti.f32, ndim=3)):
+        """Convert an OpenCV image to Tolvera pixels.
+        
+        Args:
+            f (ti.types.ndarray): OpenCV image as a float32 array.
+        """
         for i, j in ti.ndrange(self.x, self.y):
             _i, _j = self.y - j, self.x - i
             r = f[_i, _j, 2] / 255
@@ -140,6 +310,11 @@ class CV:
 
     @ti.kernel
     def px_to_cv(self, px_rgb: ti.template()):
+        """Convert Tolvera pixels to an OpenCV image.
+        
+        Args:
+            px_rgb (ti.template): Tolvera pixel RGB values.
+        """
         # TODO: untested
         for i, j in ti.ndrange(self.x, self.y):
             _i, _j = self.y - j, self.x - i
@@ -150,12 +325,22 @@ class CV:
 
     @ti.kernel
     def img_to_px(self, img: ti.types.ndarray(dtype=ti.f32, ndim=2)):
+        """Convert a grayscale image to Tolvera pixels.
+        
+        Args:
+            img (ti.types.ndarray): Grayscale image as a float32 array.
+        """
         for i, j in ti.ndrange(self.x, self.y):
             _i, _j = self.y - j, self.x - i
             p = img[_i, _j] / 255
             self.px.px.rgba[i, j] = [p, p, p, 1]
 
     def process(self):
+        """Process a frame from the camera or video.
+        
+        This method is called on each frame to read from the camera/video source
+        and convert the image to Tolvera pixels.
+        """
         self.i += 1
         if self.i % self.camera_substeps == 0:
             frame = self.capture_read()
@@ -169,8 +354,14 @@ class CV:
             self.cv_to_px(frame)
 
     def cleanup(self):
+        """Release the camera or video capture resources."""
         self.camera_capture.release()
 
     def __call__(self, *args, **kwargs):
+        """Process a frame and return the pixels.
+        
+        Returns:
+            Pixels: Tolvera pixel representation of the current frame.
+        """
         self.process()
         return self.px


### PR DESCRIPTION
closes #32 
added docstring to cv.py and the documentation for cv is now visible on reference page 
![image](https://github.com/user-attachments/assets/54eb9ba2-d8ad-4560-a232-3b76c6f0ff91)
