### PR TITLE
fix: optional-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Tölvera is [registered on PyPI](https://pypi.org/project/tolvera) and can be in
 pip install tolvera
 ```
 
+### Optional Dependencies
+
+To install optional dependencies, use the following command: 
+
+```sh
+pip install tolvera[opencv-python, iipyper, anguilla-iml, mediapipe, dualsense-controller]
+```
+
 ## Develop
 
 For development, we use [`poetry`](https://python-poetry.org/).

--- a/README.md
+++ b/README.md
@@ -44,11 +44,49 @@ pip install tolvera
 
 ### Optional Dependencies
 
-To install optional dependencies, use the following command: 
+To install all optional dependencies at once, use the following command: 
 
 ```sh
-pip install tolvera[opencv-python, iipyper, anguilla-iml, mediapipe, dualsense-controller]
+pip install tolvera[all]
+
 ```
+
+
+To install optional dependencies individually, use the following commands:
+
+opencv: Enables to use computer vision features using OpenCV.
+
+```sh
+pip install tolvera[opencv]
+
+```
+
+iipyper: Enables real-time interaction and communication features via iipyper.
+
+```sh
+pip install tolvera[iipyper]
+```
+
+iml: Integrates Machine Learning with anguilla-iml.
+
+```sh
+pip install tolvera[iml]
+```
+
+mediapipe: Adds gesture tracking, and more using MediaPipe.
+
+```sh
+pip install tolvera[mediapipe]
+
+```
+
+dualsense: Provides support for the DualSense Controller (PS5).
+
+```sh
+pip install tolvera[dualsense]
+
+```
+
 
 ## Develop
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ jsons = "^1.6.3"
 sardine = "^0.0.0b3"
 torch = "^2.2.2"
 tqdm = "^4.66.4"
+opencv-python = {version = "^4.8.1.78", optional = true}
+iipyper = {version = "^0.1.0b1", optional = true}
+anguilla-iml = {version = "0.3.0", optional = true}
+mediapipe = {version = "0.10.20", optional = true}
+dualsense-controller = {version = "^0.2.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.5.3"
@@ -32,11 +37,12 @@ black = "^23.11.0"
 isort = "^5.12.0"
 
 [tool.poetry.extras]
-opencv-python = ["opencv-python ^4.8.1.78"]
-iipyper = ["iipyper ^0.1.0b1"]
-anguilla-iml = ["anguilla-iml 0.3.0"]
-mediapipe = ["mediapipe 0.10.20"]
-dualsense-controller = ["dualsense-controller ^0.2.0"]
+opencv = ["opencv-python"]
+iipyper = ["iipyper"]
+iml = ["anguilla-iml"]
+mediapipe = ["mediapipe"]
+dualsense = ["dualsense-controller"]
+all = ["opencv-python", "iipyper", "anguilla-iml", "mediapipe", "dualsense-controller"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,9 @@ documentation = "https://intelligent-instruments-lab.github.io/tolvera/"
 python = ">=3.10, <3.13"
 taichi = "^1.7.0"
 jsons = "^1.6.3"
-opencv-python = "^4.8.1.78"
-iipyper = "^0.1.0b1"
-anguilla-iml = "0.3.0"
 sardine = "^0.0.0b3"
-mediapipe = "0.10.20"
 torch = "^2.2.2"
 tqdm = "^4.66.4"
-dualsense-controller = "^0.2.0"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.5.3"
@@ -35,6 +30,13 @@ mkdocs-awesome-pages-plugin = "^2.9.2"
 pytest = "^7.4.3"
 black = "^23.11.0"
 isort = "^5.12.0"
+
+[tool.poetry.extras]
+opencv-python = ["opencv-python ^4.8.1.78"]
+iipyper = ["iipyper ^0.1.0b1"]
+anguilla-iml = ["anguilla-iml 0.3.0"]
+mediapipe = ["mediapipe 0.10.20"]
+dualsense-controller = ["dualsense-controller ^0.2.0"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
closes #43 
- It gives users more control over which dependency groups to install
- It's more maintainable as the project grows
- Users can install specific optional dependency groups with pip install tolvera [optional_dependency_name]
- Updated README.md (add the installation process of optional dependency)