### PR TITLE
Format __init__.py with black and isort

### DIFF
--- a/src/tolvera/__init__.py
+++ b/src/tolvera/__init__.py
@@ -1,13 +1,14 @@
 from fire import Fire as run
 
 from .context import TolveraContext
+from .dualsense import DualSense
 from .particles import *
 from .patches import *
 from .pixels import *
+from .rec import VideoRecorder
 from .state import StateDict
+from .tolvera_ import Tolvera
 from .utils import *
 from .vera import Vera
-from .tolvera_ import Tolvera
-from .rec import VideoRecorder
-from .dualsense import DualSense
+
 # from .sf import *


### PR DESCRIPTION
This PR fixes formatting issues by running isort and black on src/tolvera/__init__.py . 

issue : #20
