### PR TITLE
Remove position update from noise kernel

### DIFF
--- a/src/tolvera/__init__.py
+++ b/src/tolvera/__init__.py
@@ -1,13 +1,14 @@
 from fire import Fire as run
 
 from .context import TolveraContext
+from .dualsense import DualSense
 from .particles import *
 from .patches import *
 from .pixels import *
+from .rec import VideoRecorder
 from .state import StateDict
+from .tolvera_ import Tolvera
 from .utils import *
 from .vera import Vera
-from .tolvera_ import Tolvera
-from .rec import VideoRecorder
-from .dualsense import DualSense
+
 # from .sf import *

--- a/src/tolvera/vera/forces.py
+++ b/src/tolvera/vera/forces.py
@@ -56,6 +56,7 @@ def attract(particles: ti.template(), pos: ti.math.vec2, mass: ti.f32, radius: t
             continue
         particles.field[i].vel += attract_particle(p, pos, mass, radius)
 
+
 @ti.func
 def _attract(particles: ti.template(), pos: ti.math.vec2, mass: ti.f32, radius: ti.f32):
     """Attract the particles to a position.
@@ -98,6 +99,7 @@ def attract_species(
             continue
         particles.field[i].vel += attract_particle(p, pos, mass, radius)
 
+
 @ti.func
 def _attract_species(
     particles: ti.template(),
@@ -122,6 +124,7 @@ def _attract_species(
         if p.species != species:
             continue
         particles.field[i].vel += attract_particle(p, pos, mass, radius)
+
 
 @ti.func
 def attract_particle(
@@ -287,11 +290,16 @@ def noise(particles: ti.template(), weight: ti.f32):
         p = particles.field[i]
         if p.active == 0:
             continue
-        particles.field[i].vel += (ti.Vector([ti.random() - 0.5, ti.random() - 0.5]) * weight)
-        particles.field[i].pos += p.vel * p.speed * p.active
+        particles.field[i].vel += (
+            ti.Vector([ti.random() - 0.5, ti.random() - 0.5]) * weight
+        )
+        # particles.field[i].pos += p.vel * p.speed * p.active
+
 
 @ti.kernel
-def centripetal(particles: ti.template(), centre: ti.math.vec2, direction: ti.i32, weight: ti.f32):
+def centripetal(
+    particles: ti.template(), centre: ti.math.vec2, direction: ti.i32, weight: ti.f32
+):
     """Apply a centripetal force to the particles.
 
     Args:
@@ -306,8 +314,11 @@ def centripetal(particles: ti.template(), centre: ti.math.vec2, direction: ti.i3
             continue
         particles.field[i].vel += centripetal_particle(p, centre, direction, weight)
 
+
 @ti.func
-def centripetal_particle(p: ti.template(), centre: ti.math.vec2, direction: ti.i32, weight: ti.f32) -> ti.math.vec2:
+def centripetal_particle(
+    p: ti.template(), centre: ti.math.vec2, direction: ti.i32, weight: ti.f32
+) -> ti.math.vec2:
     """Apply a centripetal force to a particle.
 
     Args:


### PR DESCRIPTION
This PR removes the position update from the noise( ) kernel.

Position updates are already handled in the move( ) , so updating position inside noise( ) caused particles to move multiple times per simulation step and made behavior dependent on kernel order.

The change ensures noise( ) only perturbs velocity, keeping position updates centralized and particle behavior predictable.